### PR TITLE
chore(ci,e2e): run firestore+auth in API tests, wait for 9099, bump P…

### DIFF
--- a/apps/mobile/playwright.config.ts
+++ b/apps/mobile/playwright.config.ts
@@ -16,6 +16,7 @@ export default defineConfig({
       command: "npm run dev:firestore",
       port: 8080,
       reuseExistingServer: true,
+      timeout: 180_000,
       cwd: "../../",
       env: process.env as Record<string, string>,
     },
@@ -23,6 +24,7 @@ export default defineConfig({
       command: "npm run dev:api",
       port: API_PORT,
       reuseExistingServer: true,
+      timeout: 180_000,
       cwd: "../../",
       env: {
         ...process.env,
@@ -36,6 +38,7 @@ export default defineConfig({
       command: `npx expo start --web --port ${EXPO_WEB_PORT} --non-interactive`,
       port: EXPO_WEB_PORT,
       reuseExistingServer: true,
+      timeout: 180_000,
       cwd: "../../apps/mobile",
       env: {
         ...process.env,

--- a/apps/web/playwright.config.ts
+++ b/apps/web/playwright.config.ts
@@ -15,6 +15,7 @@ export default defineConfig({
       command: "npm run dev:firestore",
       port: 8080,
       reuseExistingServer: true,
+      timeout: 180_000,
       cwd: "../../",
       env: process.env as Record<string, string>,
     },
@@ -22,6 +23,7 @@ export default defineConfig({
       command: "npm run dev:api",
       port: API_PORT,
       reuseExistingServer: true,
+      timeout: 180_000,
       cwd: "../../",
       env: {
         ...process.env,
@@ -35,6 +37,7 @@ export default defineConfig({
       command: `npm run dev -- --port ${WEB_PORT} --strictPort`,
       port: WEB_PORT,
       reuseExistingServer: true,
+      timeout: 180_000,
       cwd: "../../apps/web",
       env: {
         ...process.env,

--- a/package.json
+++ b/package.json
@@ -14,11 +14,9 @@
         "dev:be": "npm-run-all --parallel dev:emulators dev:api",
         "dev:fe": "npm-run-all --parallel dev:web dev:mobile",
         "lint": "eslint apps --fix --max-warnings=0",
-        "test:api": "npx firebase emulators:exec --only firestore --project local-project \"npm run --workspace=apps/api test:e2e\"",
+        "test:api": "npx firebase emulators:exec --only firestore,auth --project local-project \"npm run --workspace=apps/api test:e2e\"",
         "test:web": "npx playwright test -c apps/web/playwright.config.ts",
-        "test:mobile": "npx playwright test -c apps/mobile/playwright.config.ts",
-        "bundle:modular": "node tools/project-flattener/index.js --preset modular -O bundles",
-        "bundle:all": "node tools/project-flattener/index.js --preset single -o bundles/all.txt"
+        "test:mobile": "npx playwright test -c apps/mobile/playwright.config.ts"
     },
     "devDependencies": {
         "@playwright/test": "^1.55.1",


### PR DESCRIPTION
…laywright timeouts to 180s